### PR TITLE
Renames CRDs: identityapiresources ->apiresources, identityclients -> oauthclients

### DIFF
--- a/crd/apiresource.yaml
+++ b/crd/apiresource.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: identityapiresources.stable.contrib.identityserver.io
+  name: apiresources.stable.contrib.identityserver.io
 spec:
   group: stable.contrib.identityserver.io
   version: v1
   scope: Namespaced
   names:
-    plural: identityapiresources
-    singular: identityapiresource
-    kind: IdentityApiResource
+    plural: apiresources
+    singular: apiresource
+    kind: ApiResource
     shortNames:
     - idapi
   subresources:

--- a/crd/apiresource.yaml
+++ b/crd/apiresource.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: apiresources.stable.contrib.identityserver.io
+  name: apiresources.contrib.identityserver.io
 spec:
-  group: stable.contrib.identityserver.io
+  group: contrib.identityserver.io
   version: v1
   scope: Namespaced
   names:

--- a/crd/apiresource.yaml
+++ b/crd/apiresource.yaml
@@ -11,7 +11,8 @@ spec:
     singular: apiresource
     kind: ApiResource
     shortNames:
-    - idapi
+    - apr
+    - apires
   subresources:
     status: {}
   validation:

--- a/crd/oauthclient.yaml
+++ b/crd/oauthclient.yaml
@@ -11,7 +11,8 @@ spec:
     singular: oauthclient
     kind: OauthClient
     shortNames:
-    - idc
+    - oac
+    - client
   subresources:
     status: {}
   validation:

--- a/crd/oauthclient.yaml
+++ b/crd/oauthclient.yaml
@@ -1,15 +1,15 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: identityclients.stable.contrib.identityserver.io
+  name: oauthclients.stable.contrib.identityserver.io
 spec:
   group: stable.contrib.identityserver.io
   version: v1
   scope: Namespaced
   names:
-    plural: identityclients
-    singular: identityclient
-    kind: IdentityClient
+    plural: oauthclients
+    singular: oauthclient
+    kind: OauthClient
     shortNames:
     - idc
   subresources:

--- a/crd/oauthclient.yaml
+++ b/crd/oauthclient.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: oauthclients.stable.contrib.identityserver.io
+  name: oauthclients.contrib.identityserver.io
 spec:
-  group: stable.contrib.identityserver.io
+  group: contrib.identityserver.io
   version: v1
   scope: Namespaced
   names:

--- a/src/Contrib.IdentityServer4.KubernetesStore.sln
+++ b/src/Contrib.IdentityServer4.KubernetesStore.sln
@@ -10,7 +10,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "crd", "crd", "{383C57F7-3011-4E49-A835-D5934859E0F3}"
 ProjectSection(SolutionItems) = preProject
 	..\crd\apiresource.yaml = ..\crd\apiresource.yaml
-	..\crd\identityclient.yaml = ..\crd\identityclient.yaml
+	..\crd\oauthclient.yaml = ..\crd\oauthclient.yaml
 EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{B30BEE06-409C-4D16-8BE6-4FBD5C6E20AB}"

--- a/src/Library/ApiResourceResource.cs
+++ b/src/Library/ApiResourceResource.cs
@@ -7,7 +7,7 @@ namespace Contrib.IdentityServer4.KubernetesStore
 {
     public class ApiResourceResource : CustomResource<ApiResource>, IPayloadPatchable<ApiResourceResource>
     {
-        public new static CustomResourceDefinition Definition { get; } = Crd.For(pluralName: "identityapiresources", kind: "IdentityApiResource");
+        public new static CustomResourceDefinition Definition { get; } = Crd.For(pluralName: "apiresources", kind: "ApiResource");
 
         public ApiResourceResource()
             : base(Definition)

--- a/src/Library/ClientResource.cs
+++ b/src/Library/ClientResource.cs
@@ -7,7 +7,7 @@ namespace Contrib.IdentityServer4.KubernetesStore
 {
     public class ClientResource : CustomResource<Client>, IPayloadPatchable<ClientResource>
     {
-        public new static CustomResourceDefinition Definition { get; } = Crd.For(pluralName: "identityclients", kind: "IdentityClient");
+        public new static CustomResourceDefinition Definition { get; } = Crd.For(pluralName: "oauthclients", kind: "OauthClient");
 
         public ClientResource()
             : base(Definition)

--- a/src/Library/Crd.cs
+++ b/src/Library/Crd.cs
@@ -5,6 +5,6 @@ namespace Contrib.IdentityServer4.KubernetesStore
     internal static class Crd
     {
         public static CustomResourceDefinition For(string pluralName, string kind)
-            => new CustomResourceDefinition("stable.contrib.identityserver.io/v1", pluralName, kind);
+            => new CustomResourceDefinition("contrib.identityserver.io/v1", pluralName, kind);
     }
 }


### PR DESCRIPTION
Getting rid of the "identity" prefix of the custom resources to allow better naming (e.g. "IdentityResource" instead of "IdentityIdentityResource"), see PR https://github.com/AXOOM/Contrib.IdentityServer4.KubernetesStore/pull/3 