### PR TITLE
Prevents KubernetesResourceStore to throw on duplicate scope names

### DIFF
--- a/src/Library/DuplicateScopeFilteringInMemoryResourcesStore.cs
+++ b/src/Library/DuplicateScopeFilteringInMemoryResourcesStore.cs
@@ -1,8 +1,8 @@
+using System.Collections.Generic;
+using System.Linq;
 using IdentityServer4.Models;
 using IdentityServer4.Stores;
 using Microsoft.Extensions.Logging;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Contrib.IdentityServer4.KubernetesStore
 {
@@ -12,7 +12,8 @@ namespace Contrib.IdentityServer4.KubernetesStore
             ILogger logger,
             IEnumerable<IdentityResource> identityResources = null,
             IEnumerable<ApiResource> apiResources = null)
-            : base(EnsureUniqueIndentityScopeNames(identityResources, logger, apiResources), EnsureUniqueApiResourceScopeNames(apiResources, logger, identityResources)) { }
+            : base(EnsureUniqueIndentityScopeNames(identityResources, logger, apiResources), EnsureUniqueApiResourceScopeNames(apiResources, logger, identityResources))
+        {}
 
         internal static IEnumerable<ApiResource> EnsureUniqueApiResourceScopeNames(IEnumerable<ApiResource> apiResources, ILogger logger, IEnumerable<IdentityResource> identityResources)
         {
@@ -22,7 +23,6 @@ namespace Contrib.IdentityServer4.KubernetesStore
             {
                 var resultApiResource = apiResource;
                 foreach (var apiResourceScope in apiResource.Scopes)
-                {
                     if (allApiScopeNamesSoFar.Add(apiResourceScope.Name))
                     {
                         if (identityScopeNames.Contains(apiResourceScope.Name))
@@ -36,7 +36,6 @@ namespace Contrib.IdentityServer4.KubernetesStore
                         logger.LogError($"Duplicate Identity scope found: '{apiResource.Name}'. This is an invalid configuration. Use different names for Identity scopes.");
                         resultApiResource = CloneWithScopesExcept(resultApiResource, apiResourceScope);
                     }
-                }
                 yield return resultApiResource;
             }
         }
@@ -68,20 +67,13 @@ namespace Contrib.IdentityServer4.KubernetesStore
             var allIdentityScopeNamesSoFar = new HashSet<string>();
             var apiScopeNames = new HashSet<string>(apiResources.SelectMany(r => r.Scopes.Select(s => s.Name)));
             foreach (var identityResource in identityResources)
-            {
                 if (allIdentityScopeNamesSoFar.Add(identityResource.Name))
-                {
                     if (apiScopeNames.Contains(identityResource.Name))
                         logger.LogError($"Duplicate Identity scope name found: '{identityResource.Name}', it is used by another API scope. This is an invalid configuration. Use different names for Identity and API scopes.");
                     else
                         yield return identityResource;
-                }
                 else
-                {
                     logger.LogError($"Duplicate Identity scope found: '{identityResource.Name}'. This is an invalid configuration. Use different names for Identity scopes.");
-                }
-            }
         }
-
     }
 }

--- a/src/Library/DuplicateScopeFilteringInMemoryResourcesStore.cs
+++ b/src/Library/DuplicateScopeFilteringInMemoryResourcesStore.cs
@@ -1,0 +1,90 @@
+using IdentityServer4.Models;
+using IdentityServer4.Stores;
+using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Contrib.IdentityServer4.KubernetesStore
+{
+    public class DuplicateScopeFilteringInMemoryResourcesStore : InMemoryResourcesStore
+    {
+        public DuplicateScopeFilteringInMemoryResourcesStore(
+            ILogger logger,
+            IEnumerable<IdentityResource> identityResources = null,
+            IEnumerable<ApiResource> apiResources = null)
+            : base(EnsureUniqueIndentityScopeNames(identityResources, logger, apiResources), EnsureUniqueApiResourceScopeNames(apiResources, logger, identityResources)) { }
+
+        internal static IEnumerable<ApiResource> EnsureUniqueApiResourceScopeNames(IEnumerable<ApiResource> apiResources, ILogger logger, IEnumerable<IdentityResource> identityResources)
+        {
+            var allApiScopeNamesSoFar = new List<string>();
+            var identityScopeNames = identityResources.Select(s => s.Name).ToList();
+            foreach (var apiResource in apiResources)
+            {
+                var resultApiResource = apiResource;
+                foreach (var apiResourceScope in apiResource.Scopes)
+                {
+                    if (allApiScopeNamesSoFar.Contains(apiResourceScope.Name))
+                    {
+                        logger.LogError($"Duplicate Identity scope found: '{apiResource.Name}'. This is an invalid configuration. Use different names for Identity scopes.");
+                        resultApiResource = CloneWithScopesExcept(resultApiResource, apiResourceScope);
+                    }
+                    else if (identityScopeNames.Contains(apiResourceScope.Name))
+                    {
+                        resultApiResource = CloneWithScopesExcept(resultApiResource, apiResourceScope);
+                        logger.LogError($"Duplicate Identity scope name found: '{apiResource.Name}', it is used by another API scope. This is an invalid configuration. Use different names for Identity and API scopes.");
+                    }
+                    else
+                    {
+                        allApiScopeNamesSoFar.Add(apiResourceScope.Name);
+                    }
+                }
+                yield return resultApiResource;
+            }
+        }
+
+        private static ApiResource CloneWithScopesExcept(ApiResource original, Scope apiScopeToExclude)
+        {
+            var result = Clone(original);
+            result.Scopes = result.Scopes.Where(s => s != apiScopeToExclude).ToList();
+            return result;
+        }
+
+        private static ApiResource Clone(ApiResource original)
+        {
+            return new ApiResource
+            {
+                Name = original.Name,
+                Scopes = original.Scopes,
+                UserClaims = original.UserClaims,
+                DisplayName = original.DisplayName,
+                Description = original.Description,
+                ApiSecrets = original.ApiSecrets,
+                Enabled = original.Enabled,
+                Properties = original.Properties
+            };
+        }
+
+        internal static IEnumerable<IdentityResource> EnsureUniqueIndentityScopeNames(IEnumerable<IdentityResource> identityResources, ILogger logger, IEnumerable<ApiResource> apiResources)
+        {
+            var allIdentityScopeNamesSoFar = new List<string>();
+            var apiScopeNames = apiResources.SelectMany(r => r.Scopes.Select(s => s.Name)).ToList();
+            foreach (var identityResource in identityResources)
+            {
+                if (allIdentityScopeNamesSoFar.Contains(identityResource.Name))
+                {
+                    logger.LogError($"Duplicate Identity scope found: '{identityResource.Name}'. This is an invalid configuration. Use different names for Identity scopes.");
+                }
+                else if (apiScopeNames.Contains(identityResource.Name))
+                {
+                    logger.LogError($"Duplicate Identity scope name found: '{identityResource.Name}', it is used by another API scope. This is an invalid configuration. Use different names for Identity and API scopes.");
+                }
+                else
+                {
+                    allIdentityScopeNamesSoFar.Add(identityResource.Name);
+                    yield return identityResource;
+                }
+            }
+        }
+
+    }
+}

--- a/src/Library/KubernetesResourceStore.cs
+++ b/src/Library/KubernetesResourceStore.cs
@@ -1,17 +1,18 @@
+using Contrib.KubeClient.CustomResources;
+using IdentityServer4.Models;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Contrib.KubeClient.CustomResources;
-using IdentityServer4.Models;
-using IdentityServer4.Stores;
 
 namespace Contrib.IdentityServer4.KubernetesStore
 {
     [ExcludeFromCodeCoverage]
-    public class KubernetesResourceStore : InMemoryResourcesStore
+    public class KubernetesResourceStore : DuplicateScopeFilteringInMemoryResourcesStore
     {
-        public KubernetesResourceStore(ICustomResourceWatcher<IdentityResourceResource> identityResourceWatcher, ICustomResourceWatcher<ApiResourceResource> apiResourceWatcher, IEnumerable<IdentityResource> defaultIdentityResources = null)
-            : base(identityResourceWatcher.RawResources.Select(resource => resource.Spec).Concat(defaultIdentityResources), apiResourceWatcher.RawResources.Select(resource => resource.Spec))
-        {}
+        public KubernetesResourceStore(ILogger<KubernetesResourceStore> logger, ICustomResourceWatcher<IdentityResourceResource> identityResourceWatcher, ICustomResourceWatcher<ApiResourceResource> apiResourceWatcher, IEnumerable<IdentityResource> defaultIdentityResources = null)
+            : base(logger, identityResourceWatcher.RawResources.Select(resource => resource.Spec).Concat(defaultIdentityResources ?? Enumerable.Empty<IdentityResource>()), apiResourceWatcher.RawResources.Select(resource => resource.Spec))
+        { }
+
     }
 }

--- a/src/UnitTests/DuplicateScopeFilteringInMemoryResourcesStoreFacts.cs
+++ b/src/UnitTests/DuplicateScopeFilteringInMemoryResourcesStoreFacts.cs
@@ -1,0 +1,192 @@
+using FluentAssertions;
+using IdentityServer4.Models;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Contrib.IdentityServer4.KubernetesStore
+{
+    public class DuplicateScopeFilteringInMemoryResourcesStoreFacts
+    {
+        private readonly Mock<ILogger<DuplicateScopeFilteringInMemoryResourcesStore>> _loggerMock;
+
+        public DuplicateScopeFilteringInMemoryResourcesStoreFacts()
+        {
+            _loggerMock = new Mock<ILogger<DuplicateScopeFilteringInMemoryResourcesStore>>();
+        }
+
+        [Fact]
+        public void EnsureUniqueIndentityScopeNames_LogsNoErrorForNoIdentityResource()
+        {
+            var identityResources = new List<IdentityResource>();
+
+            DuplicateScopeFilteringInMemoryResourcesStore
+                .EnsureUniqueIndentityScopeNames(identityResources, _loggerMock.Object, new List<ApiResource>()).ToList();
+            _loggerMock.VerifyLog(LogLevel.Error, Times.Never());
+        }
+
+        [Fact]
+        public void EnsureUniqueIndentityScopeNames_LogsNoErrorForSingleIdentityResource()
+        {
+            var identityResource = new IdentityResource("IdentityResource1", new[] { "" });
+            var identityResources = new List<IdentityResource>() { identityResource };
+
+            DuplicateScopeFilteringInMemoryResourcesStore
+                .EnsureUniqueIndentityScopeNames(identityResources, _loggerMock.Object, new List<ApiResource>()).ToList();
+            _loggerMock.VerifyLog(LogLevel.Error, Times.Never());
+        }
+
+        [Fact]
+        public void EnsureUniqueIndentityScopeNames_LogsNoErrorForIdentityResourcesWithDistinctNames()
+        {
+            var identityResource1 = new IdentityResource("IdentityResource1", new[] { "" });
+            var identityResource2 = new IdentityResource("IdentityResource2", new[] { "" });
+            var identityResources = new List<IdentityResource>() { identityResource1, identityResource2 };
+
+            DuplicateScopeFilteringInMemoryResourcesStore
+                .EnsureUniqueIndentityScopeNames(identityResources, _loggerMock.Object, new List<ApiResource>()).ToList();
+            _loggerMock.VerifyLog(LogLevel.Error, Times.Never());
+        }
+
+        [Fact]
+        public void EnsureUniqueIndentityScopeNames_LogsErrorForIdentityResourcesWithSameName()
+        {
+            var identityResource1 = new IdentityResource("IdentityResource1", new[] { "" });
+            var identityResource2 = new IdentityResource("IdentityResource1", new[] { "" });
+            var identityResources = new List<IdentityResource>() { identityResource1, identityResource2 };
+
+            DuplicateScopeFilteringInMemoryResourcesStore
+                .EnsureUniqueIndentityScopeNames(identityResources, _loggerMock.Object, new List<ApiResource>()).ToList();
+            _loggerMock.VerifyLog(LogLevel.Error, Times.Once());
+        }
+
+        [Fact]
+        public void EnsureUniqueIndentityScopeNames_ReturnsOnlyIdentityResourcesWithDistinctNames()
+        {
+            var identityResource1 = new IdentityResource("IdentityResource1", new[] { "" });
+            var identityResource2 = new IdentityResource("IdentityResource1", new[] { "" });
+            var identityResource3 = new IdentityResource("IdentityResource3", new[] { "" });
+            var identityResources = new List<IdentityResource>() { identityResource1, identityResource2, identityResource3 };
+
+            var result = DuplicateScopeFilteringInMemoryResourcesStore
+                .EnsureUniqueIndentityScopeNames(identityResources, _loggerMock.Object, new List<ApiResource>()).ToList();
+            result.Select(r => r.Name).Should().OnlyHaveUniqueItems();
+        }
+
+
+        //############
+
+        [Fact]
+        public void EnsureUniqueApiResourceScopeNames_LogsNoErrorForNoApiResource()
+        {
+            var apiResources = new List<ApiResource>();
+
+            DuplicateScopeFilteringInMemoryResourcesStore
+                .EnsureUniqueApiResourceScopeNames(apiResources, _loggerMock.Object, new List<IdentityResource>()).ToList();
+            _loggerMock.VerifyLog(LogLevel.Error, Times.Never());
+        }
+
+        [Fact]
+        public void EnsureUniqueApiResourceScopeNames_LogsNoErrorForSingleApiResourceWithSingleScope()
+        {
+            var apiResources = new List<ApiResource>
+            {
+                new ApiResource(){Scopes = {new Scope(){Name = "scope1"}}}
+            };
+
+            DuplicateScopeFilteringInMemoryResourcesStore
+                .EnsureUniqueApiResourceScopeNames(apiResources, _loggerMock.Object, new List<IdentityResource>()).ToList();
+            _loggerMock.VerifyLog(LogLevel.Error, Times.Never());
+        }
+
+        [Fact]
+        public void EnsureUniqueApiResourceScopeNames_LogsNoErrorForApiResourcesWithDistinctScopeNames()
+        {
+            var apiResources = new List<ApiResource>
+            {
+                new ApiResource(){Scopes = {new Scope(){Name = "scope1"}}},
+                new ApiResource("scope2"){Scopes = {new Scope(){Name = "scope3"}}},
+            };
+
+            DuplicateScopeFilteringInMemoryResourcesStore
+                .EnsureUniqueApiResourceScopeNames(apiResources, _loggerMock.Object, new List<IdentityResource>()).ToList();
+            _loggerMock.VerifyLog(LogLevel.Error, Times.Never());
+        }
+
+        [Fact]
+        public void EnsureUniqueApiResourceScopeNames_LogsErrorsForApiResourcesWithDuplicateScopeNames()
+        {
+            var apiResources = new List<ApiResource>
+            {
+                new ApiResource(){Scopes = {new Scope(){Name = "scope1"}}},
+                new ApiResource("scope1"){Scopes = {new Scope(){Name = "scope3"}, new Scope(){Name = "scope3"}}},
+            };
+
+            DuplicateScopeFilteringInMemoryResourcesStore
+                .EnsureUniqueApiResourceScopeNames(apiResources, _loggerMock.Object, new List<IdentityResource>()).ToList();
+            _loggerMock.VerifyLog(LogLevel.Error, Times.Exactly(2));
+        }
+
+        [Fact]
+        public void EnsureUniqueApiResourceScopeNames_LogsErrorForApiResourcesWithSameScopeName()
+        {
+            var apiResources = new List<ApiResource>
+            {
+                new ApiResource(){Scopes = {new Scope(){Name = "scope1"}}},
+                new ApiResource(){Scopes = {new Scope(){Name = "scope1"}}},
+            };
+            DuplicateScopeFilteringInMemoryResourcesStore
+                .EnsureUniqueApiResourceScopeNames(apiResources, _loggerMock.Object, new List<IdentityResource>()).ToList();
+            _loggerMock.VerifyLog(LogLevel.Error, Times.Once());
+        }
+
+        [Fact]
+        public void EnsureUniqueApiResourceScopeNames_ReturnsOnlyApiResourcesWithDistinctNames()
+        {
+            var apiResources = new List<ApiResource>
+            {
+                new ApiResource(){Scopes = {new Scope(){Name = "scope1"}}},
+                new ApiResource("ApiResource1"){Scopes = { new Scope() { Name = "scope1" }, new Scope() { Name = "scope3" }, new Scope(){Name = "scope3"}}},
+            };
+
+            var result = DuplicateScopeFilteringInMemoryResourcesStore
+                .EnsureUniqueApiResourceScopeNames(apiResources, _loggerMock.Object, new List<IdentityResource>()).ToList();
+            result.Should().BeEquivalentTo(new List<ApiResource>
+            {
+                new ApiResource(){Scopes = {new Scope(){Name = "scope1"}}},
+                new ApiResource("ApiResource1"){Scopes = {new Scope(){Name = "scope3"}}},
+            });
+        }
+
+        [Fact]
+        public void EnsureUniqueApiResourceScopeNames_LogsErrorWhenApiResourceHasSameScopeNameAsIdentityResource()
+        {
+            var apiResources = new List<ApiResource>
+            {
+                new ApiResource(){Scopes = {new Scope(){Name = "scope1"}}},
+                new ApiResource(){Scopes = {new Scope(){Name = "scope2"}}},
+            };
+            DuplicateScopeFilteringInMemoryResourcesStore
+                .EnsureUniqueApiResourceScopeNames(apiResources, _loggerMock.Object, new List<IdentityResource> { new IdentityResource("scope1", new []{""}) }).ToList();
+            _loggerMock.VerifyLog(LogLevel.Error, Times.Once());
+        }
+
+
+        [Fact]
+        public void EnsureUniqueIndentityScopeNames_LogsErrorWhenApiResourceHasSameScopeNameAsIdentityResource()
+        {
+            var identityResource1 = new IdentityResource("scope1", new[] { "" });
+            var identityResource2 = new IdentityResource("scope2", new[] { "" });
+            var identityResources = new List<IdentityResource> { identityResource1, identityResource2 };
+
+            var apiResources = new List<ApiResource> { new ApiResource { Scopes = { new Scope { Name = "scope1" } } } };
+
+            DuplicateScopeFilteringInMemoryResourcesStore
+                .EnsureUniqueIndentityScopeNames(identityResources, _loggerMock.Object, apiResources).ToList();
+            _loggerMock.VerifyLog(LogLevel.Error, Times.Once());
+        }
+
+    }
+}


### PR DESCRIPTION
Currently, a single accidentally deployed API or Identity Resource can render the identity server unusable for all clients. 

We are seeing exceptions like this:
```
An unhandled exception has occurred while executing the request.
System.Exception: Duplicate API scopes found. This is an invalid configuration. Use different names for API scopes. Scopes found: oem2customer1-trumpf-backend.api.machines, oem2customer1-trumpf-backend.api.materialconsumptions, oem2customer1-trumpf-backend.api.toolusage, oem2customer1-trumpf-backend.api.programs, oem1customer1-trumpf-backend.api.machines, oem1customer1-trumpf-backend.api.materialconsumptions, oem1customer1-trumpf-backend.api.toolusage, oem1customer1-trumpf-backend.api.programs
   at void IdentityServer4.Stores.IResourceStoreExtensions.CheckForDuplicates(string[] identityScopeNames, string[] apiScopeNames)
   at void IdentityServer4.Stores.IResourceStoreExtensions.Validate(IEnumerable<IdentityResource> identity, IEnumerable<ApiResource> apiResources)
   at async Task<Resources> IdentityServer4.Stores.IResourceStoreExtensions.GetAllEnabledResourcesAsync(IResourceStore store)
   at async Task<Dictionary<string, object>> IdentityServer4.ResponseHandling.DiscoveryResponseGenerator.CreateDiscoveryDocumentAsync(string baseUrl, string issuerUri)
```

This pull request aims to still log this kind of errors, but instead of failing hard, it gracefully degrades by just omitting the duplicate scopes. This way, some clients might stop working while others remain able to authenticate. 