### PR TITLE
Derive OauthClient.spec.clientId from resource namespace and name

### DIFF
--- a/crd/apiresource.yaml
+++ b/crd/apiresource.yaml
@@ -21,15 +21,13 @@ spec:
       properties:
         spec:
           type: object
-          required:
-            - name
           properties:
             enabled:
               type: boolean
               description: Indicates if this resource is enabled. This defaults to true.
             name:
               type: string
-              description: The unique name of the resource.
+              description: The unique name of the resource. If not set, the resource namespace and name (joined with a hyphen) are used instead.
             displayName:
               type: string
               description: Display name of the resource.

--- a/crd/identityresource.yaml
+++ b/crd/identityresource.yaml
@@ -20,15 +20,13 @@ spec:
       properties:
         spec:
           type: object
-          required:
-            - name
           properties:
             enabled:
               type: boolean
               description: Indicates if this resource is enabled. This defaults to true.
             name:
               type: string
-              description: The unique name of the resource.
+              description: The unique name of the resource. If not set, the resource namespace and name (joined with a hyphen) are used instead.
             displayName:
               type: string
               description: Display name of the resource.

--- a/crd/oauthclient.yaml
+++ b/crd/oauthclient.yaml
@@ -21,7 +21,6 @@ spec:
       properties:
         spec:
           required:
-            - clientId
             - clientName
             - allowedGrantTypes
           properties:
@@ -30,7 +29,7 @@ spec:
               description: Specifies if client is enabled. This defaults to true.
             clientId:
               type: string
-              description: Unique ID of the client.
+              description: Unique ID of the client. If not set, the resource namespace and name (joined with a hyphen) are used instead.
             clientSecrets:
               type: array
               description: Client secrets - only relevant for flows that require a secret.

--- a/src/Library/KubernetesClientStore.cs
+++ b/src/Library/KubernetesClientStore.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Contrib.KubeClient.CustomResources;
+using IdentityServer4.Models;
 using IdentityServer4.Stores;
 
 namespace Contrib.IdentityServer4.KubernetesStore
@@ -9,7 +10,16 @@ namespace Contrib.IdentityServer4.KubernetesStore
     public class KubernetesClientStore : InMemoryClientStore
     {
         public KubernetesClientStore(ICustomResourceWatcher<ClientResource> clientWatcher)
-            : base(clientWatcher.Select(resource => resource.Spec))
+            : base(clientWatcher.Select(GetClient))
         {}
+
+        private static Client GetClient(ClientResource resource)
+        {
+            var client = resource.Spec;
+            if (string.IsNullOrEmpty(client.ClientId))
+                client.ClientId = resource.Metadata.Namespace + "-" + resource.Metadata.Name;
+
+            return client;
+        }
     }
 }

--- a/src/Library/KubernetesCorsPolicyService.cs
+++ b/src/Library/KubernetesCorsPolicyService.cs
@@ -12,12 +12,15 @@ namespace Contrib.IdentityServer4.KubernetesStore
     public class KubernetesCorsPolicyService : InMemoryCorsPolicyService
     {
         public KubernetesCorsPolicyService(ILogger<KubernetesCorsPolicyService> logger, ICustomResourceWatcher<ClientResource> clientWatcher)
-            : base(logger, clientWatcher.Select(client => EnsureWellFormedAllowedCorsOrigins(client, logger)))
+            : base(logger, clientWatcher.Select(resource => GetClient(resource, logger)))
         { }
 
-        private static Client EnsureWellFormedAllowedCorsOrigins(ClientResource clientResource, ILogger logger)
+        private static Client GetClient(ClientResource resource, ILogger logger)
         {
-            var client = clientResource.Spec;
+            var client = resource.Spec;
+            if (string.IsNullOrEmpty(client.ClientId))
+                client.ClientId = resource.Metadata.Namespace + "-" + resource.Metadata.Name;
+
             if (client.AllowedCorsOrigins.All(IsWellFormedUriString))
                 return client;
 

--- a/src/Library/KubernetesResourceStore.cs
+++ b/src/Library/KubernetesResourceStore.cs
@@ -11,8 +11,28 @@ namespace Contrib.IdentityServer4.KubernetesStore
     public class KubernetesResourceStore : DuplicateScopeFilteringInMemoryResourcesStore
     {
         public KubernetesResourceStore(ILogger<KubernetesResourceStore> logger, ICustomResourceWatcher<IdentityResourceResource> identityResourceWatcher, ICustomResourceWatcher<ApiResourceResource> apiResourceWatcher, IEnumerable<IdentityResource> defaultIdentityResources = null)
-            : base(logger, identityResourceWatcher.Select(resource => resource.Spec).Concat(defaultIdentityResources ?? Enumerable.Empty<IdentityResource>()), apiResourceWatcher.Select(resource => resource.Spec))
-        { }
+            : base(
+                logger,
+                identityResourceWatcher.Select(GetIdentityResource).Concat(defaultIdentityResources ?? Enumerable.Empty<IdentityResource>()),
+                apiResourceWatcher.Select(GetApiResource))
+        {}
 
+        private static IdentityResource GetIdentityResource(IdentityResourceResource resource)
+        {
+            var identityResource = resource.Spec;
+            if (string.IsNullOrEmpty(identityResource.Name))
+                identityResource.Name = resource.Metadata.Namespace + "-" + resource.Metadata.Name;
+
+            return identityResource;
+        }
+
+        private static ApiResource GetApiResource(ApiResourceResource resource)
+        {
+            var apiResource = resource.Spec;
+            if (string.IsNullOrEmpty(apiResource.Name))
+                apiResource.Name = resource.Metadata.Namespace + "-" + resource.Metadata.Name;
+
+            return apiResource;
+        }
     }
 }


### PR DESCRIPTION
This makes it easier to avoid duplicate `clientId`s.